### PR TITLE
Removing unnecessary `windows.h` include from headers

### DIFF
--- a/drawing.h
+++ b/drawing.h
@@ -49,7 +49,7 @@ namespace btui {
     constexpr inline CanvasIntoFrameMappingInfo1D MakeCanvasIntoFrameMappingInfo1D(uint32_t CanvasLength, uint32_t FrameLength, Align DimensionAlign) {
         CanvasIntoFrameMappingInfo1D ioInfo;
 
-        ioInfo.ioLength = min(CanvasLength, FrameLength);
+        ioInfo.ioLength = std::min(CanvasLength, FrameLength);
 
         switch (DimensionAlign) {
         case btui::AlignStart:

--- a/windowbase.cpp
+++ b/windowbase.cpp
@@ -4,6 +4,7 @@
 #include "windowbase.h"
 #include <combaseapi.h>
 #include <shellapi.h>
+#include <windows.h>
 
 constexpr uint32_t charWidth = 10;
 constexpr uint32_t charHeight = 15;

--- a/windowbase.h
+++ b/windowbase.h
@@ -385,8 +385,8 @@ namespace btui {
         CursorType cursorType;
 
         void UpdateFunction(bool* Initialized);
-        static __int64 __stdcall WindowProcStatic(HWND Hwnd, unsigned int Msg, unsigned __int64 WParam, __int64 LParam);
-        __int64 WindowProc(HWND Hwnd, unsigned int Msg, unsigned __int64 WParam, __int64 LParam);
+        static std::int64_t __stdcall WindowProcStatic(HWND Hwnd, unsigned int Msg, std::uint64_t WParam, std::int64_t LParam);
+        std::int64_t WindowProc(HWND Hwnd, unsigned int Msg, std::uint64_t WParam, std::int64_t LParam);
         void ProcessTasks();
         void CancelTasks();
         bool InvokeOnWindowThread(std::function<void()> Func);

--- a/windowbase.h
+++ b/windowbase.h
@@ -9,7 +9,6 @@
 #include <string>
 #include <thread>
 #include <vector>
-#include <windows.h>
 
 namespace btui {
     static constexpr inline uint32_t FromRGB(uint8_t R, uint8_t G, uint8_t B) {

--- a/windowbase.h
+++ b/windowbase.h
@@ -10,6 +10,9 @@
 #include <thread>
 #include <vector>
 
+typedef struct HWND__* HWND;
+typedef struct HINSTANCE__* HINSTANCE;
+
 namespace btui {
     static constexpr inline uint32_t FromRGB(uint8_t R, uint8_t G, uint8_t B) {
         return (uint32_t)R << 16 | (uint32_t)G << 8 | (uint32_t)B;
@@ -171,10 +174,10 @@ namespace btui {
             uint32_t r2EndX = Rect2.x + Rect2.width;
             uint32_t r2EndY = Rect2.y + Rect2.height;
 
-            out.x = max(Rect1.x, Rect2.x);
-            out.y = max(Rect1.y, Rect2.y);
-            uint32_t outEndX = min(r1EndX, r2EndX);
-            uint32_t outEndY = min(r1EndY, r2EndY);
+            out.x = std::max(Rect1.x, Rect2.x);
+            out.y = std::max(Rect1.y, Rect2.y);
+            uint32_t outEndX = std::min(r1EndX, r2EndX);
+            uint32_t outEndY = std::min(r1EndY, r2EndY);
 
             if (outEndX <= out.x || outEndY <= out.y) {
                 out.x = 0;
@@ -382,8 +385,8 @@ namespace btui {
         CursorType cursorType;
 
         void UpdateFunction(bool* Initialized);
-        static LRESULT CALLBACK WindowProcStatic(HWND Hwnd, UINT Msg, WPARAM WParam, LPARAM LParam);
-        LRESULT WindowProc(HWND Hwnd, UINT Msg, WPARAM WParam, LPARAM LParam);
+        static __int64 __stdcall WindowProcStatic(HWND Hwnd, unsigned int Msg, unsigned __int64 WParam, __int64 LParam);
+        __int64 WindowProc(HWND Hwnd, unsigned int Msg, unsigned __int64 WParam, __int64 LParam);
         void ProcessTasks();
         void CancelTasks();
         bool InvokeOnWindowThread(std::function<void()> Func);


### PR DESCRIPTION
Removed `#include <windows.h>` header from `windowbase.h`. No other headers contained references to `windows.h`.